### PR TITLE
Add Check-In habit mode and APK build workflow

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -27,7 +27,7 @@ jobs:
           channel: "stable"
 
       - name: Accept Android licenses
-        run: flutter doctor --android-licenses
+        run: yes | flutter doctor --android-licenses
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,43 @@
+name: Build APK
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.2"
+          channel: "stable"
+
+      - name: Accept Android licenses
+        run: flutter doctor --android-licenses
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: grove-release-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+          retention-days: 30

--- a/lib/models/grove_models.dart
+++ b/lib/models/grove_models.dart
@@ -28,6 +28,8 @@ class RelapseEvent {
 
 enum GrowthStage { seed, sprout, sapling, youngTree, groveTree }
 
+enum HabitMode { abstain, checkIn }
+
 GrowthStage stageFromDays(int days) {
   if (days <= 1)  return GrowthStage.seed;
   if (days <= 7)  return GrowthStage.sprout;
@@ -59,8 +61,11 @@ class HabitTree {
   final DateTime           startDate;
   DateTime                 lastReset;
   final List<RelapseEvent> _relapses;
+  final HabitMode          mode;
+  final Set<DateTime>      _checkInDays;
 
-  List<RelapseEvent> get relapses => _relapses;
+  List<RelapseEvent> get relapses     => _relapses;
+  Set<DateTime>      get checkInDays  => _checkInDays;
 
   final int geneticSeed;
 
@@ -72,16 +77,49 @@ class HabitTree {
     required this.lastReset,
     List<RelapseEvent>? relapses,
     int? geneticSeed,
-  })  : _relapses   = relapses != null ? List<RelapseEvent>.of(relapses) : [],
-  geneticSeed = geneticSeed ?? id.hashCode;
+    this.mode = HabitMode.abstain,
+    Set<DateTime>? checkInDays,
+  })  : _relapses    = relapses != null ? List<RelapseEvent>.of(relapses) : [],
+        _checkInDays = checkInDays != null ? Set<DateTime>.of(checkInDays) : <DateTime>{},
+        geneticSeed  = geneticSeed ?? id.hashCode;
 
-  int         get daysElapsed => DateTime.now().difference(lastReset).inDays;
+  int get checkInStreak {
+    if (_checkInDays.isEmpty) return 0;
+    final now     = DateTime.now();
+    final today   = DateTime(now.year, now.month, now.day);
+    int streak = 0;
+    for (int i = 0; ; i++) {
+      final d = today.subtract(Duration(days: i));
+      if (_checkInDays.contains(d)) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  bool get checkedInToday {
+    final now  = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    return _checkInDays.contains(today);
+  }
+
+  int get daysElapsed => mode == HabitMode.abstain
+    ? DateTime.now().difference(lastReset).inDays
+    : checkInStreak;
+
   int         get totalDays   => DateTime.now().difference(startDate).inDays;
   GrowthStage get stage       => stageFromDays(daysElapsed);
 
-  int get peakDays => _relapses.isEmpty
-  ? daysElapsed
-  : math.max(daysElapsed, _relapses.map((e) => e.peakDays).reduce(math.max));
+  int get peakDays {
+    if (mode == HabitMode.checkIn) {
+      return _checkInDays.isEmpty ? 0 : checkInStreak;
+    }
+    return _relapses.isEmpty
+      ? daysElapsed
+      : math.max(daysElapsed, _relapses.map((e) => e.peakDays).reduce(math.max));
+  }
 
   double get stageProgress {
     final d = daysElapsed;
@@ -93,8 +131,8 @@ class HabitTree {
   }
 
   Set<DateTime> get relapseDays => _relapses
-  .map((e) => DateTime(e.timestamp.year, e.timestamp.month, e.timestamp.day))
-  .toSet();
+    .map((e) => DateTime(e.timestamp.year, e.timestamp.month, e.timestamp.day))
+    .toSet();
 
   Map<String, dynamic> toMap() => {
     'id':          id,
@@ -104,6 +142,8 @@ class HabitTree {
     'lastReset':   lastReset.toIso8601String(),
     'relapses':    _relapses.map((r) => r.toMap()).toList(),
     'geneticSeed': geneticSeed,
+    'mode':        mode.index,
+    'checkInDays': _checkInDays.map((d) => d.toIso8601String()).toList(),
   };
 
   String toJson() => jsonEncode(toMap());
@@ -115,13 +155,17 @@ class HabitTree {
     startDate:   DateTime.parse(m['startDate'] as String),
     lastReset:   DateTime.parse(m['lastReset'] as String),
     relapses: (m['relapses'] as List<dynamic>? ?? [])
-    .map((r) => RelapseEvent.fromMap(r as Map<String, dynamic>))
-    .toList(),
+      .map((r) => RelapseEvent.fromMap(r as Map<String, dynamic>))
+      .toList(),
     geneticSeed: m['geneticSeed'] as int?,
+    mode:        m['mode'] != null ? HabitMode.values[m['mode'] as int] : HabitMode.abstain,
+    checkInDays: (m['checkInDays'] as List<dynamic>?)
+      ?.map((d) => DateTime.parse(d as String))
+      .toSet(),
   );
 
   factory HabitTree.fromJson(String s) =>
-  HabitTree.fromMap(jsonDecode(s) as Map<String, dynamic>);
+    HabitTree.fromMap(jsonDecode(s) as Map<String, dynamic>);
 
   HabitTree copyWith({
     String?             id,
@@ -131,14 +175,18 @@ class HabitTree {
     DateTime?           lastReset,
     List<RelapseEvent>? relapses,
     int?                geneticSeed,
+    HabitMode?          mode,
+    Set<DateTime>?      checkInDays,
   }) =>
-  HabitTree(
-    id:          id          ?? this.id,
-    name:        name        ?? this.name,
-    color:       color       ?? this.color,
-    startDate:   startDate   ?? this.startDate,
-    lastReset:   lastReset   ?? this.lastReset,
-    relapses:    relapses    ?? List<RelapseEvent>.of(_relapses),
-    geneticSeed: geneticSeed ?? this.geneticSeed,
-  );
+    HabitTree(
+      id:          id          ?? this.id,
+      name:        name        ?? this.name,
+      color:       color       ?? this.color,
+      startDate:   startDate   ?? this.startDate,
+      lastReset:   lastReset   ?? this.lastReset,
+      relapses:    relapses    ?? List<RelapseEvent>.of(_relapses),
+      geneticSeed: geneticSeed ?? this.geneticSeed,
+      mode:        mode        ?? this.mode,
+      checkInDays: checkInDays ?? Set<DateTime>.of(_checkInDays),
+    );
 }

--- a/lib/providers/grove_model.dart
+++ b/lib/providers/grove_model.dart
@@ -54,7 +54,7 @@ class GroveModel extends ChangeNotifier {
     }
   }
 
-  void addHabit({required String name, required Color color}) {
+  void addHabit({required String name, required Color color, HabitMode mode = HabitMode.abstain}) {
     final now = DateTime.now();
     _habits.add(HabitTree(
       id:        'habit_${now.millisecondsSinceEpoch}',
@@ -62,7 +62,42 @@ class GroveModel extends ChangeNotifier {
       color:     color,
       startDate: now,
       lastReset: now,
+      mode:      mode,
     ));
+    _persist();
+    notifyListeners();
+  }
+
+  void toggleCheckIn(String habitId, {DateTime? date}) {
+    final i = _habits.indexWhere((h) => h.id == habitId);
+    if (i == -1 || _habits[i].mode != HabitMode.checkIn) return;
+
+    final now   = date ?? DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final original = _habits[i];
+    final updatedDays = Set<DateTime>.of(original.checkInDays);
+
+    if (updatedDays.contains(today)) {
+      updatedDays.remove(today);
+    } else {
+      updatedDays.add(today);
+    }
+
+    _habits[i] = original.copyWith(checkInDays: updatedDays);
+    _persist();
+    notifyListeners();
+  }
+
+  void removeCheckInOnDate(String habitId, DateTime date) {
+    final i = _habits.indexWhere((h) => h.id == habitId);
+    if (i == -1 || _habits[i].mode != HabitMode.checkIn) return;
+
+    final target = _habits[i];
+    final cleanedDate = DateTime(date.year, date.month, date.day);
+    if (!target.checkInDays.contains(cleanedDate)) return;
+
+    final updatedDays = Set<DateTime>.of(target.checkInDays)..remove(cleanedDate);
+    _habits[i] = target.copyWith(checkInDays: updatedDays);
     _persist();
     notifyListeners();
   }

--- a/lib/screens/habit_detail_screen.dart
+++ b/lib/screens/habit_detail_screen.dart
@@ -70,6 +70,7 @@ class _HabitDetailScreenState extends State<HabitDetailScreen> {
     }
     final habit = context.watch<GroveModel>().habitById(widget.habitId);
     final theme = context.watch<GroveSettings>().theme;
+    final isCheckIn = habit?.mode == HabitMode.checkIn;
     if (habit == null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted && !_isDeleting) Navigator.of(context).pop();
@@ -84,16 +85,50 @@ class _HabitDetailScreenState extends State<HabitDetailScreen> {
           _appBar(context, habit, theme),
           SliverToBoxAdapter(child: _treeHero(habit)),
           SliverToBoxAdapter(child: _stats(habit, theme)),
-          SliverToBoxAdapter(child: _timeSinceRelapseCard(habit, theme)),
+          isCheckIn
+            ? SliverToBoxAdapter(child: _checkInStreakCard(habit, theme))
+            : SliverToBoxAdapter(child: _timeSinceRelapseCard(habit, theme)),
           SliverToBoxAdapter(child: _calendarSection(habit, theme)),
-          SliverToBoxAdapter(child: _historyHeader(habit, theme)),
-          habit.relapses.isEmpty
-          ? SliverToBoxAdapter(child: _noHistory(theme))
-          : SliverList(delegate: SliverChildBuilderDelegate(
-            (_, i) => RelapseEventTile(event: habit.relapses[i], index: i),
-            childCount: habit.relapses.length)),
-            SliverToBoxAdapter(child: _deleteSection(context, habit, theme)),
-            const SliverToBoxAdapter(child: SizedBox(height: 80)),
+          if (!isCheckIn) ...[
+            SliverToBoxAdapter(child: _historyHeader(habit, theme)),
+            habit.relapses.isEmpty
+              ? SliverToBoxAdapter(child: _noHistory(theme))
+              : SliverList(delegate: SliverChildBuilderDelegate(
+                (_, i) => RelapseEventTile(event: habit.relapses[i], index: i),
+                childCount: habit.relapses.length)),
+          ] else ...[
+            SliverToBoxAdapter(child: _checkInHistoryHeader(habit, theme)),
+            if (habit.checkInDays.isEmpty)
+              SliverToBoxAdapter(child: _noHistory(theme, checkIn: true))
+            else
+              SliverList(delegate: SliverChildBuilderDelegate(
+                (_, i) {
+                  final sorted = habit.checkInDays.toList()..sort((a, b) => b.compareTo(a));
+                  final date = sorted[i];
+                  return Container(
+                    margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+                    padding: const EdgeInsets.all(14),
+                    decoration: BoxDecoration(color: theme.surface, borderRadius: BorderRadius.circular(16),
+                    border: Border.all(color: theme.surfaceHigh)),
+                    child: Row(children: [
+                      Container(width: 28, height: 28,
+                        decoration: BoxDecoration(color: habit.color.withValues(alpha: 0.12), shape: BoxShape.circle),
+                        alignment: Alignment.center,
+                        child: Icon(Icons.check, size: 14, color: habit.color)),
+                      const SizedBox(width: 12),
+                      Expanded(child: Text(
+                        DateFormat('EEEE, MMMM d, yyyy').format(date),
+                        style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: theme.textPrimary),
+                      )),
+                      Text(DateFormat('h:mm a').format(date), style: TextStyle(fontSize: 11, color: theme.textMuted)),
+                    ]),
+                  );
+                },
+                childCount: habit.checkInDays.length,
+              )),
+          ],
+          SliverToBoxAdapter(child: _deleteSection(context, habit, theme)),
+          const SliverToBoxAdapter(child: SizedBox(height: 80)),
         ],
       ),
     );
@@ -132,6 +167,71 @@ class _HabitDetailScreenState extends State<HabitDetailScreen> {
         ]),
       ),
     );
+  }
+
+  Widget _checkInStreakCard(HabitTree habit, GroveTheme theme) {
+    final checkedIn = habit.checkedInToday;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 18),
+        decoration: BoxDecoration(
+          color:        habit.color.withValues(alpha: 0.07),
+          borderRadius: BorderRadius.circular(20),
+          border:       Border.all(color: habit.color.withValues(alpha: 0.22)),
+        ),
+        child: Column(children: [
+          Text(checkedIn ? 'Today is checked in' : 'Today is not yet checked in',
+               style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600,
+                                color: theme.textSecondary, letterSpacing: 0.8)),
+                      const SizedBox(height: 12),
+                      Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
+                        _streakUnit(value: habit.checkInStreak, label: 'STREAK', color: habit.color),
+                        _streakUnit(value: habit.checkInDays.length, label: 'TOTAL', color: GroveTheme.streakGold),
+                        _streakUnit(value: habit.totalDays, label: 'DAYS', color: theme.textSecondary),
+                      ]),
+                      const SizedBox(height: 14),
+                      GestureDetector(
+                        onTap: () {
+                          HapticFeedback.mediumImpact();
+                          context.read<GroveModel>().toggleCheckIn(habit.id);
+                        },
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 24),
+                          decoration: BoxDecoration(
+                            color: checkedIn ? theme.surfaceHigh : habit.color,
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Row(mainAxisSize: MainAxisSize.min, children: [
+                            Icon(
+                              checkedIn ? Icons.check_circle : Icons.check_circle_outline,
+                              size: 18,
+                              color: checkedIn ? habit.color : Colors.white,
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              checkedIn ? 'Already Checked In' : 'Check In Today',
+                              style: TextStyle(
+                                fontSize: 14, fontWeight: FontWeight.w600,
+                                color: checkedIn ? habit.color : Colors.white,
+                              ),
+                            ),
+                          ]),
+                        ),
+                      ),
+        ]),
+      ),
+    );
+  }
+
+  Widget _streakUnit({required int value, required String label, required Color color}) {
+    return Column(mainAxisSize: MainAxisSize.min, children: [
+      Text(value.toString(),
+        style: TextStyle(fontSize: 28, fontWeight: FontWeight.w700, color: color,
+                         fontFeatures: const [FontFeature.tabularFigures()])),
+      const SizedBox(height: 2),
+      Text(label, style: TextStyle(fontSize: 9, color: GroveTheme.slateGrey, fontWeight: FontWeight.w600, letterSpacing: 0.5)),
+    ]);
   }
 
   Widget _appBar(BuildContext ctx, HabitTree habit, GroveTheme theme) =>
@@ -257,7 +357,11 @@ class _HabitDetailScreenState extends State<HabitDetailScreen> {
       const SizedBox(width: 10),
       StatChip(label: 'Peak Record',    value: '${habit.peakDays}d',    color: GroveTheme.streakGold),
       const SizedBox(width: 10),
-      StatChip(label: 'Relapses',       value: '${habit.relapses.length}', color: GroveTheme.clayRed),
+      StatChip(
+        label: habit.mode == HabitMode.checkIn ? 'Check-ins' : 'Relapses',
+        value: habit.mode == HabitMode.checkIn ? '${habit.checkInDays.length}' : '${habit.relapses.length}',
+        color: habit.mode == HabitMode.checkIn ? habit.color : GroveTheme.clayRed,
+      ),
     ]),
   );
 
@@ -435,10 +539,26 @@ class _HabitDetailScreenState extends State<HabitDetailScreen> {
     ]),
   );
 
-  Widget _noHistory(GroveTheme theme) => Padding(
+  Widget _noHistory(GroveTheme theme, {bool checkIn = false}) => Padding(
     padding: const EdgeInsets.symmetric(vertical: 32),
-    child: Center(child: Text('No relapses recorded. Keep growing.',
-                              style: TextStyle(color: theme.textMuted, fontStyle: FontStyle.italic, fontSize: 13))),
+    child: Center(child: Text(
+      checkIn ? 'No check-ins yet. Start today!'
+              : 'No relapses recorded. Keep growing.',
+      style: TextStyle(color: theme.textMuted, fontStyle: FontStyle.italic, fontSize: 13))),
+  );
+
+  Widget _checkInHistoryHeader(HabitTree habit, GroveTheme theme) => Padding(
+    padding: const EdgeInsets.fromLTRB(20, 24, 20, 12),
+    child: Row(children: [
+      Text('Check-In History',
+           style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: theme.textSecondary, letterSpacing: 1.0)),
+           const Spacer(),
+           Container(
+             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+             decoration: BoxDecoration(color: habit.color.withValues(alpha: 0.12), borderRadius: BorderRadius.circular(12)),
+             child: Text('${habit.checkInDays.length} total',
+                         style: TextStyle(fontSize: 11, color: habit.color, fontWeight: FontWeight.w500))),
+    ]),
   );
 
   Widget _deleteSection(BuildContext ctx, HabitTree habit, GroveTheme theme) => Padding(

--- a/lib/widgets/add_habit_sheet.dart
+++ b/lib/widgets/add_habit_sheet.dart
@@ -18,6 +18,7 @@ class _AddHabitSheetState extends State<AddHabitSheet> {
   final _hexCtrl  = TextEditingController();
   Color _color    = GroveTheme.treePalette[0];
   bool  _validHex = true;
+  HabitMode _mode = HabitMode.abstain;
 
   @override
   void initState() { super.initState(); _hexCtrl.text = _colorToHex(_color); }
@@ -53,6 +54,62 @@ class _AddHabitSheetState extends State<AddHabitSheet> {
                                labelText: 'Habit Name', hintText: 'e.g. Alcohol, Smoking, Social media',
                                prefixIcon: Icon(Icons.edit_outlined, size: 18, color: theme.textMuted)),
                            ),
+                      const SizedBox(height: 20),
+                      Text('TRACKING MODE', style: TextStyle(fontSize: 11, color: theme.textSecondary, letterSpacing: 1.0)),
+                      const SizedBox(height: 12),
+                      Row(children: [
+                        Expanded(child: GestureDetector(
+                          onTap: () => setState(() => _mode = HabitMode.abstain),
+                          child: AnimatedContainer(
+                            duration: const Duration(milliseconds: 200),
+                            padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 10),
+                            decoration: BoxDecoration(
+                              color: _mode == HabitMode.abstain ? theme.primary.withValues(alpha: 0.12) : theme.surface,
+                              borderRadius: BorderRadius.circular(14),
+                              border: Border.all(
+                                color: _mode == HabitMode.abstain ? theme.primary : theme.textMuted.withValues(alpha: 0.3),
+                                width: _mode == HabitMode.abstain ? 2 : 1,
+                              ),
+                            ),
+                            child: Column(children: [
+                              Icon(Icons.shield_outlined, size: 22, color: _mode == HabitMode.abstain ? theme.primary : theme.textMuted),
+                              const SizedBox(height: 6),
+                              Text('Abstain', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700,
+                                color: _mode == HabitMode.abstain ? theme.primary : theme.textSecondary)),
+                              const SizedBox(height: 2),
+                              Text('Auto-grows daily', style: TextStyle(fontSize: 9, color: theme.textMuted)),
+                              const SizedBox(height: 2),
+                              Text('Tap on relapse', style: TextStyle(fontSize: 9, color: theme.textMuted)),
+                            ]),
+                          ),
+                        )),
+                        const SizedBox(width: 8),
+                        Expanded(child: GestureDetector(
+                          onTap: () => setState(() => _mode = HabitMode.checkIn),
+                          child: AnimatedContainer(
+                            duration: const Duration(milliseconds: 200),
+                            padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 10),
+                            decoration: BoxDecoration(
+                              color: _mode == HabitMode.checkIn ? theme.primary.withValues(alpha: 0.12) : theme.surface,
+                              borderRadius: BorderRadius.circular(14),
+                              border: Border.all(
+                                color: _mode == HabitMode.checkIn ? theme.primary : theme.textMuted.withValues(alpha: 0.3),
+                                width: _mode == HabitMode.checkIn ? 2 : 1,
+                              ),
+                            ),
+                            child: Column(children: [
+                              Icon(Icons.check_circle_outline, size: 22, color: _mode == HabitMode.checkIn ? theme.primary : theme.textMuted),
+                              const SizedBox(height: 6),
+                              Text('Check-In', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700,
+                                color: _mode == HabitMode.checkIn ? theme.primary : theme.textSecondary)),
+                              const SizedBox(height: 2),
+                              Text('Tap daily to grow', style: TextStyle(fontSize: 9, color: theme.textMuted)),
+                              const SizedBox(height: 2),
+                              Text('Streak on check-ins', style: TextStyle(fontSize: 9, color: theme.textMuted)),
+                            ]),
+                          ),
+                        )),
+                      ]),
                       const SizedBox(height: 20),
                       Text('PRESET COLORS', style: TextStyle(fontSize: 11, color: theme.textSecondary, letterSpacing: 1.0)),
                       const SizedBox(height: 12),
@@ -131,7 +188,7 @@ class _AddHabitSheetState extends State<AddHabitSheet> {
       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Give your habit a name.')));
       return;
     }
-    context.read<GroveModel>().addHabit(name: name, color: _color);
+    context.read<GroveModel>().addHabit(name: name, color: _color, mode: _mode);
     HapticFeedback.lightImpact();
     Navigator.pop(context);
   }

--- a/lib/widgets/habit_card.dart
+++ b/lib/widgets/habit_card.dart
@@ -24,11 +24,14 @@ class _HabitCardState extends State<HabitCard> {
     final model        = context.read<GroveModel>();
     final settings     = context.watch<GroveSettings>();
     final theme        = settings.theme;
-    final days         = widget.habit.daysElapsed;
-    final stage        = widget.habit.stage;
-    final relapseCount = widget.habit.relapses.length;
+    final habit        = widget.habit;
+    final days         = habit.daysElapsed;
+    final stage        = habit.stage;
+    final relapseCount = habit.relapses.length;
     final isCompact    = widget.layoutMode == LayoutMode.compactGrid;
     final isList       = widget.layoutMode == LayoutMode.compactList;
+    final isCheckIn    = habit.mode == HabitMode.checkIn;
+    final isCheckedIn  = isCheckIn && habit.checkedInToday;
 
     if (isList) {
       return GestureDetector(
@@ -37,25 +40,25 @@ class _HabitCardState extends State<HabitCard> {
           padding: const EdgeInsets.all(14),
           decoration: BoxDecoration(
             color: theme.cardBg, borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: widget.habit.color.withValues(alpha: 0.3)),
+            border: Border.all(color: habit.color.withValues(alpha: 0.3)),
           ),
           child: Row(children: [
             GestureDetector(
               onTap: () => _goDetail(context),
-              child: SizedBox(width: 60, height: 60, child: AnimatedTreeWidget(habit: widget.habit)),
+              child: SizedBox(width: 60, height: 60, child: AnimatedTreeWidget(habit: habit)),
             ),
             const SizedBox(width: 12),
             Expanded(child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-              Text(widget.habit.name, maxLines: 1, overflow: TextOverflow.ellipsis,
+              Text(habit.name, maxLines: 1, overflow: TextOverflow.ellipsis,
                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700, color: theme.textPrimary)),
                    const SizedBox(height: 4),
                    Row(children: [
                      Container(
                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                        decoration: BoxDecoration(
-                         color: widget.habit.color.withValues(alpha: 0.15), borderRadius: BorderRadius.circular(12)),
-                         child: Text(stageLabel(stage),
-                         style: TextStyle(fontSize: 10, fontWeight: FontWeight.w600, color: widget.habit.color)),
+                         color: habit.color.withValues(alpha: 0.15), borderRadius: BorderRadius.circular(12)),
+                         child: Text(isCheckIn ? '$days-day streak' : stageLabel(stage),
+                         style: TextStyle(fontSize: 10, fontWeight: FontWeight.w600, color: habit.color)),
                      ),
                      const SizedBox(width: 6),
                      Text('Day $days', style: TextStyle(fontSize: 12, color: theme.textSecondary)),
@@ -63,8 +66,18 @@ class _HabitCardState extends State<HabitCard> {
             ])),
             const SizedBox(width: 8),
             GestureDetector(
-              onTap: () => _showRelapseDialog(context, model),
-              child: const Icon(Icons.refresh_rounded, size: 20, color: GroveTheme.clayRed),
+              onTap: () => isCheckIn
+                ? _handleCheckIn(context, model, habit)
+                : _showRelapseDialog(context, model),
+              child: Icon(
+                isCheckIn
+                  ? (isCheckedIn ? Icons.check_circle : Icons.check_circle_outline)
+                  : Icons.refresh_rounded,
+                size: 20,
+                color: isCheckIn
+                  ? (isCheckedIn ? habit.color : theme.textMuted)
+                  : GroveTheme.clayRed,
+              ),
             ),
           ]),
         ),
@@ -80,11 +93,11 @@ class _HabitCardState extends State<HabitCard> {
           color:        theme.cardBg,
           borderRadius: BorderRadius.circular(isCompact ? 22 : 28),
           border: Border.all(
-            color: widget.isSelected ? widget.habit.color.withValues(alpha: 0.45) : theme.surfaceHigh,
+            color: widget.isSelected ? habit.color.withValues(alpha: 0.45) : theme.surfaceHigh,
             width: widget.isSelected ? 1.5 : 1.0,
           ),
           boxShadow: widget.isSelected && !isCompact
-          ? [BoxShadow(color: widget.habit.color.withValues(alpha: 0.18), blurRadius: 32, spreadRadius: 2)]
+          ? [BoxShadow(color: habit.color.withValues(alpha: 0.18), blurRadius: 32, spreadRadius: 2)]
           : [],
         ),
         child: Column(
@@ -93,19 +106,19 @@ class _HabitCardState extends State<HabitCard> {
             GestureDetector(
               onTap: () => _goDetail(context),
               child: Hero(
-                tag: 'tree_${widget.habit.id}',
+                tag: 'tree_${habit.id}',
                 child: Material(
                   color: Colors.transparent,
                   child: SizedBox(
                     width:  isCompact ? 100 : 175,
                     height: isCompact ? 100 : 175,
-                    child:  AnimatedTreeWidget(habit: widget.habit),
+                    child:  AnimatedTreeWidget(habit: habit),
                   ),
                 ),
               ),
             ),
             SizedBox(height: isCompact ? 8 : 10),
-            Text(widget.habit.name, maxLines: 1, overflow: TextOverflow.ellipsis,
+            Text(habit.name, maxLines: 1, overflow: TextOverflow.ellipsis,
                  style: TextStyle(fontSize: isCompact ? 15 : 22, fontWeight: FontWeight.w700,
                                   color: theme.textPrimary, letterSpacing: 0.3)),
                       SizedBox(height: isCompact ? 4 : 6),
@@ -116,9 +129,9 @@ class _HabitCardState extends State<HabitCard> {
                             Container(
                               padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 3),
                               decoration: BoxDecoration(
-                                color: widget.habit.color.withValues(alpha: 0.15), borderRadius: BorderRadius.circular(20)),
-                                child: Text(stageLabel(stage), style: TextStyle(
-                                  fontSize: 11, fontWeight: FontWeight.w600, color: widget.habit.color, letterSpacing: 0.8)),
+                                color: habit.color.withValues(alpha: 0.15), borderRadius: BorderRadius.circular(20)),
+                                child: Text(isCheckIn ? '$days-day streak' : stageLabel(stage), style: TextStyle(
+                                  fontSize: 11, fontWeight: FontWeight.w600, color: habit.color, letterSpacing: 0.8)),
                             ),
                             const SizedBox(width: 8),
                           ],
@@ -130,7 +143,9 @@ class _HabitCardState extends State<HabitCard> {
                       ),
                       if (!isCompact) ...[
                         const SizedBox(height: 4),
-                        Text(stageTagline(stage),
+                        Text(isCheckIn
+                          ? isCheckedIn ? 'Already checked in today ✓' : 'Tap below to check in'
+                          : stageTagline(stage),
                         style: TextStyle(fontSize: 11, color: theme.textMuted, fontStyle: FontStyle.italic),
                         textAlign: TextAlign.center),
                       const SizedBox(height: 16),
@@ -138,10 +153,20 @@ class _HabitCardState extends State<HabitCard> {
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
                           _OutlineAction(icon: Icons.calendar_month_outlined,
-                                         label: 'History${relapseCount > 0 ? ' ($relapseCount)' : ''}',
+                                         label: isCheckIn
+                                           ? 'History (${habit.checkInDays.length})'
+                                           : 'History${relapseCount > 0 ? ' ($relapseCount)' : ''}',
                                          color: theme.textSecondary, onTap: () => _goDetail(context)),
                                          const SizedBox(width: 10),
-                                         _OutlineAction(icon: Icons.refresh_rounded, label: 'Relapse',
+                                         if (isCheckIn)
+                                           _OutlineAction(
+                                             icon: isCheckedIn ? Icons.check_circle : Icons.check_circle_outline,
+                                             label: isCheckedIn ? 'Checked In' : 'Check In',
+                                             color: isCheckedIn ? habit.color : habit.color,
+                                             onTap: () => _handleCheckIn(context, model, habit),
+                                           )
+                                         else
+                                           _OutlineAction(icon: Icons.refresh_rounded, label: 'Relapse',
                                                         color: GroveTheme.clayRed, onTap: () => _showRelapseDialog(context, model)),
                         ],
                       ),
@@ -150,14 +175,28 @@ class _HabitCardState extends State<HabitCard> {
                         Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
                           IconButton(icon: Icon(Icons.calendar_month_outlined, size: 16, color: theme.textSecondary),
                           onPressed: () => _goDetail(context), padding: EdgeInsets.zero, constraints: const BoxConstraints()),
-                          IconButton(icon: const Icon(Icons.refresh_rounded, size: 16, color: GroveTheme.clayRed),
-                          onPressed: () => _showRelapseDialog(context, model), padding: EdgeInsets.zero, constraints: const BoxConstraints()),
+                          if (isCheckIn)
+                            IconButton(
+                              icon: Icon(
+                                isCheckedIn ? Icons.check_circle : Icons.check_circle_outline,
+                                size: 16,
+                                color: isCheckedIn ? habit.color : theme.textMuted),
+                              onPressed: () => _handleCheckIn(context, model, habit),
+                              padding: EdgeInsets.zero, constraints: const BoxConstraints())
+                          else
+                            IconButton(icon: const Icon(Icons.refresh_rounded, size: 16, color: GroveTheme.clayRed),
+                            onPressed: () => _showRelapseDialog(context, model), padding: EdgeInsets.zero, constraints: const BoxConstraints()),
                         ]),
                       ],
           ],
         ),
       ),
     );
+  }
+
+  void _handleCheckIn(BuildContext ctx, GroveModel model, HabitTree habit) {
+    HapticFeedback.mediumImpact();
+    model.toggleCheckIn(habit.id);
   }
 
   void _goDetail(BuildContext ctx) => Navigator.push(ctx,

--- a/lib/widgets/monthly_calendar.dart
+++ b/lib/widgets/monthly_calendar.dart
@@ -18,6 +18,7 @@ class MonthlyCalendar extends StatelessWidget {
     final theme          = context.watch<GroveSettings>().theme;
     final model          = context.read<GroveModel>();
     final now            = DateTime.now();
+    final isCheckIn      = habit.mode == HabitMode.checkIn;
     final targetMonth    = DateTime(now.year, now.month + monthOffset, 1);
     final monthName      = DateFormat('MMMM yyyy').format(targetMonth);
     final lastDayOfMonth = DateTime(targetMonth.year, targetMonth.month + 1, 0);
@@ -69,7 +70,6 @@ class MonthlyCalendar extends StatelessWidget {
                                        final today      = DateTime(now.year, now.month, now.day);
                                        final isToday    = cellDate == today;
                                        final isFuture   = cellDate.isAfter(today);
-                                       final isCheckIn  = habit.mode == HabitMode.checkIn;
                                        final hasRelapse = habit.relapseDays.contains(cellDate);
                                        final hasCheckIn = isCheckIn && habit.checkInDays.contains(cellDate);
                                        final hasMark    = isCheckIn ? hasCheckIn : hasRelapse;

--- a/lib/widgets/monthly_calendar.dart
+++ b/lib/widgets/monthly_calendar.dart
@@ -69,29 +69,34 @@ class MonthlyCalendar extends StatelessWidget {
                                        final today      = DateTime(now.year, now.month, now.day);
                                        final isToday    = cellDate == today;
                                        final isFuture   = cellDate.isAfter(today);
+                                       final isCheckIn  = habit.mode == HabitMode.checkIn;
                                        final hasRelapse = habit.relapseDays.contains(cellDate);
+                                       final hasCheckIn = isCheckIn && habit.checkInDays.contains(cellDate);
+                                       final hasMark    = isCheckIn ? hasCheckIn : hasRelapse;
 
                                        final cellColor = isFuture
                                        ? theme.surfaceHigh.withValues(alpha: 0.3)
-                                       : hasRelapse ? GroveTheme.clayRed.withValues(alpha: 0.7) : theme.surfaceHigh;
+                                       : hasMark
+                                         ? (isCheckIn ? habit.color.withValues(alpha: 0.7) : GroveTheme.clayRed.withValues(alpha: 0.7))
+                                         : theme.surfaceHigh;
 
                                        return Expanded(
                                          child: GestureDetector(
-                                           onTap: isFuture ? null : () {
-                                             HapticFeedback.selectionClick();
-                                             _showCellManager(context, cellDate, hasRelapse, model, theme);
-                                           },
-                                           child: Container(
-                                             margin: const EdgeInsets.all(2),
-                                             decoration: BoxDecoration(color: cellColor, borderRadius: BorderRadius.circular(8),
-                                             border: isToday ? Border.all(color: habit.color, width: 2) : null),
-                                             alignment: Alignment.center,
-                                             child: Text('$day', style: TextStyle(
-                                               fontSize: 11, fontWeight: isToday ? FontWeight.w700 : FontWeight.w500,
-                                               color: hasRelapse ? GroveTheme.dewWhite : isFuture
-                                               ? theme.textMuted.withValues(alpha: 0.5) : theme.textSecondary)),
-                                           ),
-                                         ),
+                                               onTap: isFuture ? null : () {
+                                                 HapticFeedback.selectionClick();
+                                                 _showCellManager(context, cellDate, hasMark, model, theme);
+                                               },
+                                               child: Container(
+                                                 margin: const EdgeInsets.all(2),
+                                                 decoration: BoxDecoration(color: cellColor, borderRadius: BorderRadius.circular(8),
+                                                 border: isToday ? Border.all(color: habit.color, width: 2) : null),
+                                                 alignment: Alignment.center,
+                                                 child: Text('$day', style: TextStyle(
+                                                   fontSize: 11, fontWeight: isToday ? FontWeight.w700 : FontWeight.w500,
+                                                   color: hasMark ? GroveTheme.dewWhite : isFuture
+                                                   ? theme.textMuted.withValues(alpha: 0.5) : theme.textSecondary)),
+                                               ),
+                                             ),
                                        );
                                      })),
                                    ))),
@@ -101,14 +106,15 @@ class MonthlyCalendar extends StatelessWidget {
                       _legendDot(theme.surfaceHigh), const SizedBox(width: 5),
                       Text('Clean', style: TextStyle(fontSize: 9, color: theme.textMuted)),
                       const SizedBox(width: 14),
-                      _legendDot(GroveTheme.clayRed.withValues(alpha: 0.7)), const SizedBox(width: 5),
-                      Text('Relapse', style: TextStyle(fontSize: 9, color: theme.textMuted)),
+                      _legendDot(isCheckIn ? habit.color.withValues(alpha: 0.7) : GroveTheme.clayRed.withValues(alpha: 0.7)),
+                      const SizedBox(width: 5),
+                      Text(isCheckIn ? 'Check-in' : 'Relapse', style: TextStyle(fontSize: 9, color: theme.textMuted)),
                     ]),
       ]),
     );
   }
 
-  void _showCellManager(BuildContext ctx, DateTime targetDate, bool hasRelapse,
+  void _showCellManager(BuildContext ctx, DateTime targetDate, bool hasMark,
                         GroveModel model, GroveTheme theme) {
     showModalBottomSheet(
       context: ctx, backgroundColor: theme.surfaceHigh,
@@ -118,7 +124,7 @@ class MonthlyCalendar extends StatelessWidget {
         builder: (_) => _CellManagerSheet(
           habit:      habit,
           targetDate: targetDate,
-          hasRelapse: hasRelapse,
+          hasRelapse: hasMark,
           model:      model,
           theme:      theme,
         ),
@@ -152,21 +158,25 @@ class _CellManagerSheet extends StatefulWidget {
 class _CellManagerSheetState extends State<_CellManagerSheet> {
   late final TextEditingController _reasonCtrl;
   late TimeOfDay _selectedTime;
+  late bool _isCheckIn;
 
   @override
   void initState() {
     super.initState();
     _reasonCtrl   = TextEditingController();
     _selectedTime = TimeOfDay.now();
+    _isCheckIn    = widget.habit.mode == HabitMode.checkIn;
 
-    final matches = widget.habit.relapses.where((r) =>
-    r.timestamp.year  == widget.targetDate.year  &&
-    r.timestamp.month == widget.targetDate.month &&
-    r.timestamp.day   == widget.targetDate.day).toList();
+    if (!_isCheckIn) {
+      final matches = widget.habit.relapses.where((r) =>
+      r.timestamp.year  == widget.targetDate.year  &&
+      r.timestamp.month == widget.targetDate.month &&
+      r.timestamp.day   == widget.targetDate.day).toList();
 
-    if (matches.isNotEmpty) {
-      _reasonCtrl.text = matches.first.reason;
-      _selectedTime    = TimeOfDay.fromDateTime(matches.first.timestamp);
+      if (matches.isNotEmpty) {
+        _reasonCtrl.text = matches.first.reason;
+        _selectedTime    = TimeOfDay.fromDateTime(matches.first.timestamp);
+      }
     }
   }
 
@@ -183,6 +193,11 @@ class _CellManagerSheetState extends State<_CellManagerSheet> {
       MediaQuery.of(context).viewInsets.bottom,
       MediaQuery.of(context).padding.bottom);
 
+    final dateStr = DateFormat('EEEE, MMMM d, yyyy').format(widget.targetDate);
+    final hasMark = _isCheckIn
+      ? widget.habit.checkInDays.contains(DateTime(widget.targetDate.year, widget.targetDate.month, widget.targetDate.day))
+      : widget.hasRelapse;
+
     return Padding(
       padding: EdgeInsets.fromLTRB(24, 24, 24, 24 + bottomPad),
       child: SingleChildScrollView(
@@ -196,15 +211,20 @@ class _CellManagerSheetState extends State<_CellManagerSheet> {
                 color:        theme.textMuted.withValues(alpha: 0.4),
                 borderRadius: BorderRadius.circular(2)))),
                 const SizedBox(height: 20),
-                Text(DateFormat('EEEE, MMMM d, yyyy').format(widget.targetDate),
+                Text(dateStr,
                 style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: theme.textPrimary)),
                 const SizedBox(height: 6),
-                Text(widget.hasRelapse ? '⚠️ Relapse logged on this day.' : '🌿 Clean record.',
-                     style: TextStyle(
-                       fontSize:   12,
-                       color:      widget.hasRelapse ? GroveTheme.clayRed : theme.textSecondary,
-                       fontWeight: FontWeight.w600)),
-                      const SizedBox(height: 20),
+                Text(hasMark
+                  ? (_isCheckIn ? '✅ Checked in on this day.' : '⚠️ Relapse logged on this day.')
+                  : '🌿 Clean record.',
+                  style: TextStyle(
+                    fontSize:   12,
+                    color:      hasMark
+                      ? (_isCheckIn ? widget.habit.color : GroveTheme.clayRed)
+                      : theme.textSecondary,
+                    fontWeight: FontWeight.w600)),
+                    const SizedBox(height: 20),
+                    if (!_isCheckIn) ...[
                       Text('TIME OVERRIDE',
                            style: TextStyle(color: theme.textMuted, fontSize: 11, letterSpacing: 0.5, fontWeight: FontWeight.w600)),
                            const SizedBox(height: 8),
@@ -220,7 +240,7 @@ class _CellManagerSheetState extends State<_CellManagerSheet> {
                                  padding:         const EdgeInsets.symmetric(vertical: 12)),
                            ),
                       const SizedBox(height: 16),
-                      Text(widget.hasRelapse ? 'EDIT REASON' : 'REASON (optional)',
+                      Text(hasMark ? 'EDIT REASON' : 'REASON (optional)',
                       style: TextStyle(color: theme.textMuted, fontSize: 11, letterSpacing: 0.5, fontWeight: FontWeight.w600)),
                       const SizedBox(height: 8),
                       TextField(
@@ -231,24 +251,55 @@ class _CellManagerSheetState extends State<_CellManagerSheet> {
                           hintText:       'Stress, Anxiety, Burnout, Peer pressure, Trigger? etc...',
                           contentPadding: EdgeInsets.all(12))),
                           const SizedBox(height: 24),
-                          if (widget.hasRelapse) ...[
-                            FilledButton.icon(
-                              onPressed: () {
-                                final ts = DateTime(
-                                  widget.targetDate.year, widget.targetDate.month, widget.targetDate.day,
-                                  _selectedTime.hour, _selectedTime.minute);
-                                widget.model.recordCustomRelapse(widget.habit.id, _reasonCtrl.text.trim(), ts);
-                                HapticFeedback.lightImpact();
-                                Navigator.pop(context);
-                              },
-                              icon:  const Icon(Icons.check, size: 16),
-                              label: const Text('Update Log'),
-                              style: FilledButton.styleFrom(
-                                backgroundColor: widget.habit.color,
-                                foregroundColor: Colors.white,
-                                  minimumSize:     const Size.fromHeight(48),
-                                  shape:           RoundedRectangleBorder(borderRadius: BorderRadius.circular(12))),
+                    ],
+                    if (_isCheckIn) ...[
+                      const SizedBox(height: 12),
+                      FilledButton.icon(
+                        onPressed: () {
+                           if (hasMark) {
+                             widget.model.removeCheckInOnDate(widget.habit.id, widget.targetDate);
+                           } else {
+                             widget.model.toggleCheckIn(widget.habit.id, date: widget.targetDate);
+                           }
+                           HapticFeedback.lightImpact();
+                           Navigator.pop(context);
+                         },
+                        icon: Icon(
+                          hasMark ? Icons.clear : Icons.check_circle_outline,
+                          size: 16,
+                          color: hasMark ? theme.textPrimary : Colors.white,
+                        ),
+                        label: Text(hasMark ? 'Remove Check-in' : 'Check In This Day',
+                          style: TextStyle(
+                            color: hasMark ? theme.textPrimary : Colors.white,
+                          )),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: hasMark ? theme.surfaceHigh : widget.habit.color,
+                            minimumSize:     const Size.fromHeight(48),
+                            shape:           RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              side: hasMark ? BorderSide(color: theme.textMuted.withValues(alpha: 0.3)) : BorderSide.none,
                             ),
+                        ),
+                      ),
+                    ] else if (hasMark) ...[
+                      FilledButton.icon(
+                        onPressed: () {
+                          final ts = DateTime(
+                            widget.targetDate.year, widget.targetDate.month, widget.targetDate.day,
+                            _selectedTime.hour, _selectedTime.minute);
+                          widget.model.recordCustomRelapse(widget.habit.id, _reasonCtrl.text.trim(), ts);
+                          HapticFeedback.lightImpact();
+                          Navigator.pop(context);
+                        },
+                        icon:  const Icon(Icons.check, size: 16),
+                        label: const Text('Update Log'),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: widget.habit.color,
+                          foregroundColor: Colors.white,
+                            minimumSize:     const Size.fromHeight(48),
+                            shape:           RoundedRectangleBorder(borderRadius: BorderRadius.circular(12))),
+                      ),
                       const SizedBox(height: 10),
                       OutlinedButton.icon(
                         onPressed: () {
@@ -264,25 +315,25 @@ class _CellManagerSheetState extends State<_CellManagerSheet> {
                             minimumSize:     const Size.fromHeight(48),
                             shape:           RoundedRectangleBorder(borderRadius: BorderRadius.circular(12))),
                       ),
-                          ] else ...[
-                            FilledButton.icon(
-                              onPressed: () {
-                                final ts = DateTime(
-                                  widget.targetDate.year, widget.targetDate.month, widget.targetDate.day,
-                                  _selectedTime.hour, _selectedTime.minute);
-                                widget.model.recordCustomRelapse(widget.habit.id, _reasonCtrl.text.trim(), ts);
-                                HapticFeedback.lightImpact();
-                                Navigator.pop(context);
-                              },
-                              icon:  const Icon(Icons.add, size: 16),
-                              label: const Text('Add Relapse Here'),
-                              style: FilledButton.styleFrom(
-                                backgroundColor: GroveTheme.clayRed,
-                                foregroundColor: Colors.white,
-                                  minimumSize:     const Size.fromHeight(48),
-                                  shape:           RoundedRectangleBorder(borderRadius: BorderRadius.circular(12))),
-                            ),
-                          ],
+                    ] else ...[
+                      FilledButton.icon(
+                        onPressed: () {
+                          final ts = DateTime(
+                            widget.targetDate.year, widget.targetDate.month, widget.targetDate.day,
+                            _selectedTime.hour, _selectedTime.minute);
+                          widget.model.recordCustomRelapse(widget.habit.id, _reasonCtrl.text.trim(), ts);
+                          HapticFeedback.lightImpact();
+                          Navigator.pop(context);
+                        },
+                        icon:  const Icon(Icons.add, size: 16),
+                        label: const Text('Add Relapse Here'),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: GroveTheme.clayRed,
+                          foregroundColor: Colors.white,
+                            minimumSize:     const Size.fromHeight(48),
+                            shape:           RoundedRectangleBorder(borderRadius: BorderRadius.circular(12))),
+                      ),
+                    ],
           ],
         ),
       ),


### PR DESCRIPTION
## What does this PR do?
This PR introduces a new Check-In habit mode alongside the existing Abstain mode.

Features added:
- Users can choose between Abstain and Check-In when creating a habit
- Check-In habits track daily check-ins instead of relapse-free days
- Check-in streak calculation and statistics
- Check-in history view in habit details
- Check-in actions directly from habit cards
- Calendar support for displaying check-in activity
- Persistence and serialization for Check-In data

Additionally, this PR adds a GitHub Actions workflow that automatically builds a release APK on pushes and pull requests. Thanks to @ADAIBLOG.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Other (describe below)

## How has this been tested?
Tested on pixel 6.

- Created new Abstain habits
- Created new Check-In habits
- Verified daily check-ins update streaks correctly
- Verified check-in history appears in habit details
- Verified existing Abstain habits continue functioning normally

## Checklist
- [x] Tested on a real Android device
- [x] `CHANGELOG.md` updated under `[Unreleased]` (After PR)
- [x] No new dependencies that phone home or collect data
- [x] Code follows the existing style
