### PR TITLE
checkInStreak counts from latest check-in, not today

### DIFF
--- a/lib/models/grove_models.dart
+++ b/lib/models/grove_models.dart
@@ -85,11 +85,11 @@ class HabitTree {
 
   int get checkInStreak {
     if (_checkInDays.isEmpty) return 0;
-    final now     = DateTime.now();
-    final today   = DateTime(now.year, now.month, now.day);
+    final sorted = _checkInDays.toList()..sort((a, b) => b.compareTo(a));
+    final latest = sorted.first;
     int streak = 0;
     for (int i = 0; ; i++) {
-      final d = today.subtract(Duration(days: i));
+      final d = latest.subtract(Duration(days: i));
       if (_checkInDays.contains(d)) {
         streak++;
       } else {
@@ -114,7 +114,19 @@ class HabitTree {
 
   int get peakDays {
     if (mode == HabitMode.checkIn) {
-      return _checkInDays.isEmpty ? 0 : checkInStreak;
+      if (_checkInDays.isEmpty) return 0;
+      final sorted = _checkInDays.toList()..sort();
+      int maxRun = 1;
+      int current = 1;
+      for (int i = 1; i < sorted.length; i++) {
+        if (sorted[i].difference(sorted[i - 1]).inDays == 1) {
+          current++;
+          if (current > maxRun) maxRun = current;
+        } else {
+          current = 1;
+        }
+      }
+      return maxRun;
     }
     return _relapses.isEmpty
       ? daysElapsed


### PR DESCRIPTION
## What does this PR do?
Fixes two bugs in `checkInStreak` and `peakDays` for Check-In mode habits:

1. **`checkInStreak` counted from today instead of the latest check-in date.**
   - If you check in on Day 1, skip Day 2, the streak showed 0 — making it look like all records were lost. The data was still saved, but the counting logic was wrong.
   - Now counts backward from the most recent check-in date.

2. **`peakDays` returned the current streak instead of the historical best.**
   - If you hit a 30-day streak, broke it, then started a new 3-day streak, `peakDays` showed 3 instead of 30.
   - Now scans all check-in dates to find the longest consecutive run in history.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactor / code cleanup
- [ ] Other (describe below)

## How has this been tested?
Tested on a real Android device by simulating the exact scenario:
1. Created a Check-In mode habit
2. Checked in Day 1 → streak showed 1, peak showed 1
3. Checked in Day 2 → streak showed 2, peak showed 2
4. Cancelled Day 2 check-in → streak correctly showed 1 (from Day 1), not 0
5. Checked in Day 2 again → streak showed 2
6. Verified peakDays preserved historical max after breaking and restarting a streak

## Checklist
- [x] Tested on a real Android device
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [x] No new dependencies that phone home or collect data
- [x] Code follows the existing style